### PR TITLE
Added Python 3 install for tests on CentOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: ubuntu1604
     - MOLECULE_DISTRO: centos7
-    # - MOLECULE_DISTRO: centos8
+    - MOLECULE_DISTRO: centos8
     # - MOLECULE_DISTRO: debian10
     # - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: fedora31

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,14 @@
 ---
 - hosts: all
+  gather_facts: false
+  tasks:
+    # Install Python 3 on CentOS 7 and 8, thus is just temporary
+    - name: Install Python 3 when it is not present
+      raw: test -e /usr/bin/python3 || (yum -y install python3)
+      become: true
+      changed_when: false
+
+- hosts: all
   become: true
 
   pre_tasks:

--- a/tasks/aiida-deps-debian.yml
+++ b/tasks/aiida-deps-debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Set default locale
+  become: true
+  become_user: "{{ root_user }}"
+  lineinfile:
+    dest: /etc/default/locale
+    regexp: "LC_ALL"
+    line: "LC_ALL=\"en_US.UTF-8\""
+
 - name: Install DB & more
   become: true
   become_user: "{{ root_user }}"

--- a/tasks/aiida-deps-rhel.yml
+++ b/tasks/aiida-deps-rhel.yml
@@ -1,4 +1,12 @@
 ---
+- name: Set default locale
+  become: true
+  become_user: "{{ root_user }}"
+  lineinfile:
+    dest: /etc/locale.conf
+    regexp: "LC_ALL"
+    line: "LC_ALL=\"en_US.UTF-8\""
+
 - name: Install Postgresql, RabbitMQ and necessary python packages
   become: true
   become_user: "{{ root_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,6 @@
   tags: always
   when: current_user is undefined
 
-- name: set default locale
-  become: true
-  become_user: "{{ root_user }}"
-  lineinfile:
-    dest: /etc/default/locale
-    regexp: "LC_ALL"
-    line: "LC_ALL=\"en_US.UTF-8\""
-
 - include_tasks: aiida-deps-rhel.yml
   tags: aiida_deps
   when: ansible_os_family|lower == 'redhat'


### PR DESCRIPTION
We need to install Python 3 on CentOS 7 (Python 2 present) and 8 (no Python present). We do this with a simple test. If `/usr/bin/python3` does not exist, we install it. This test should fail on Fedora and Ubuntu, which comes with Python 3 installed.