### PR TITLE
fix aiida_data_folder issue

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,3 +14,5 @@
           # - plugins
           - pseudopotentials
           - examples
+        # just to test whether this also works
+        aiida_data_folder: "/usr/local/share"

--- a/tasks/aiida-pps-oncv.yml
+++ b/tasks/aiida-pps-oncv.yml
@@ -4,7 +4,7 @@
   become: true
   become_user: "{{ root_user }}"
   file:
-    path: "{{ aiida_data_folder }}/{{ pp.folder }}"
+    path: "{{ aiida_data_folder | regex_replace('\\$\\{HOME}', current_user_home) }}/{{ pp.folder }}"
     state: directory
 
 - name: "Unpack {{ pp.file }}"

--- a/tasks/aiida-prepare.yml
+++ b/tasks/aiida-prepare.yml
@@ -88,7 +88,7 @@
   become: true
   become_user: "{{ root_user }}"
   file:
-    path: "{{ aiida_templates_folder }}"
+    path: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
     state: "directory"
     mode: 0755
 
@@ -96,6 +96,6 @@
   become: true
   become_user: "{{ root_user }}"
   file:
-    path: "{{ aiida_data_folder }}"
+    path: "{{ aiida_data_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
     state: "directory"
     mode: 0755


### PR DESCRIPTION
Some (default) folder locations contain the `${HOME}` variable - this is
a bit of a hack to worka round an unresolved ansible issue:
{{ ansible_env.HOME }} resolves to the home of the ansible user and is
unaffected by *becoming* a different user.

So, we user the current_user role to store the home location of the user
we want to target, and then replace the `${HOME}` variable in folder
paths.

This was not done for the AiiDA data and template folders, which is now
fixed by this commit.