### PR TITLE
Update for aiida-core version 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .galaxy_install_info
+.vscode/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,14 +79,14 @@ aiida_plugins: "{{ aiida_plugin_versions.keys() }}"
 aiida_pseudopotentials:
   - name: SSSP_1.1_efficiency
     file: SSSP_efficiency_pseudos.aiida
-    url: https://archive.materialscloud.org/file/2018.0001/v3
+    url: https://legacy-archive.materialscloud.org/file/2018.0001/v3
     home_page: https://materialscloud.org/sssp/
     description: >-
      Standard Solid State Pseudopotentials (efficiency)
      for the PBE functional
   - name: SSSP_1.1_precision
     file: SSSP_precision_pseudos.aiida
-    url: https://archive.materialscloud.org/file/2018.0001/v3
+    url: https://legacy-archive.materialscloud.org/file/2018.0001/v3
     home_page: https://materialscloud.org/sssp/
     description: >-
      Standard Solid State Pseudopotentials (precision)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-aiida_version: "1.1.1"
+aiida_version: "1.2.1"
 aiida_tag: v{{ aiida_version }}
 aiida_extras:
   - rest
@@ -66,10 +66,10 @@ aiida_plugin_versions:
   aiida_bigdft: "0.1.0a0"
   # aiida_gudhi: "0.1.0a3"
   # aiida_phtools: "0.1.0a1"
-  aiida_quantumespresso: "3.0.0a6"
+  aiida_quantumespresso: "3.0.0"
   # aiida_raspa: "1.0.0a2"
   aiida_siesta: "1.0.1"
-  aiida_yambo: "1.0.0"
+  aiida_yambo: "1.1.1"
   aiida_wannier90: "2.0.1"
   aiida_wannier90_workflows: "1.0.1"
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,8 +6,15 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
-  roles:
-    - role: marvel-nccr.aiida
+  tasks:
+    - name: Create dummy pw executable
+      copy:
+        content: ""
+        dest: /usr/bin/pw.x
+        force: no
+        mode: 0666
+    - include_role:
+        name: marvel-nccr.aiida
       vars:
         aiida_components:
           - computers

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,3 +16,9 @@
           - examples
         # just to test whether this also works
         aiida_data_folder: "/usr/local/share"
+        quantum_espresso_version: "6.5"
+        quantum_espresso_executables:
+          - name: pw
+            folder: "/usr/bin"
+            executable: "pw.x"
+            plugin: quantumespresso.pw

--- a/tasks/plugins/aiida-bigdft.yml
+++ b/tasks/plugins/aiida-bigdft.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_bigdft_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up bigdft codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-cp2k.yml
+++ b/tasks/plugins/aiida-cp2k.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_cp2k_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up cp2k codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-fleur.yml
+++ b/tasks/plugins/aiida-fleur.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_fleur_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up fleur codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-gudhi.yml
+++ b/tasks/plugins/aiida-gudhi.yml
@@ -4,9 +4,10 @@
     name: git+https://github.com/ltalirz/aiida-gudhi@v{{ aiida_gudhi_version }}
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up gudhi codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-phtools.yml
+++ b/tasks/plugins/aiida-phtools.yml
@@ -4,9 +4,10 @@
     name: git+https://github.com/ltalirz/aiida-phtools@v{{ aiida_phtools_version }}
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up phtools codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-quantumespresso.yml
+++ b/tasks/plugins/aiida-quantumespresso.yml
@@ -4,12 +4,11 @@
     name: aiida-quantumespresso
     version: "{{ aiida_quantumespresso_version }}"
     virtualenv: "{{ aiida_venv }}"
-    extra_args: "--pre"  # remove after release for AiiDA 1.0 is out
   register: aiida_qe_installed
-  changed_when: false  # remove when aiida-yambo no longer locks version
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: aiida_qe_installed.changed
 
 - name: set up quantum_espresso codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-raspa.yml
+++ b/tasks/plugins/aiida-raspa.yml
@@ -4,9 +4,10 @@
     name: git+https://github.com/yakutovicha/aiida-raspa@v{{ aiida_raspa_version }}
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up raspa codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-siesta.yml
+++ b/tasks/plugins/aiida-siesta.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_siesta_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up siesta codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-wannier90-workflows.yml
+++ b/tasks/plugins/aiida-wannier90-workflows.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_wannier90_workflows_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - include_role:
     name: release_notes

--- a/tasks/plugins/aiida-wannier90.yml
+++ b/tasks/plugins/aiida-wannier90.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_wannier90_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up wannier90 codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-yambo.yml
+++ b/tasks/plugins/aiida-yambo.yml
@@ -1,21 +1,14 @@
 ---
-- name: "install aiida-yambo-{{ aiida_yambo_version }} from github"
+- name: "install aiida-yambo-{{ aiida_yambo_version }} from PyPI"
   pip:
-    name: git+https://github.com/yambo-code/yambo-aiida@v{{ aiida_yambo_version }}
+    name: aiida-yambo
+    version: "{{ aiida_yambo_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  changed_when: false  # remove when aiida-yambo no longer locks version
-  notify: reentry scan
 
-# - name: "install aiida-yambo-{{ aiida_yambo_version }} from PyPI"
-#   pip:
-#     name: aiida-yambo
-#     version: "{{ aiida_yambo_version }}"
-#     virtualenv: "{{ aiida_venv }}"
-#   register: pip_install
-#   notify: reentry scan
-
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up yambo codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/aiida-zeopp.yml
+++ b/tasks/plugins/aiida-zeopp.yml
@@ -5,9 +5,10 @@
     version: "{{ aiida_zeopp_version }}"
     virtualenv: "{{ aiida_venv }}"
   register: pip_install
-  notify: reentry scan
 
-- meta: flush_handlers
+- name: reentry scan
+  shell: "{{ aiida_venv }}/bin/reentry scan"
+  when: pip_install.changed
 
 - name: set up zeopp codes for localhost
   include_tasks: code-setup.yml

--- a/tasks/plugins/code-setup.yml
+++ b/tasks/plugins/code-setup.yml
@@ -14,17 +14,12 @@
   - name: Get absolute path
     set_fact:
       abspath: "{{ aiida_code.folder |  regex_replace('\\$\\{HOME}', current_user_home) }}/{{ aiida_code.executable }}"
+
   - name: "Copy {{ aiida_code.template }} to setup the AiiDA code"
     template:
       src: "{{ aiida_code.template }}"
       dest: "{{ aiida_templates_folder }}/{{ aiida_code.label }}.yml"
 
-#  - name: "Set up the {{ aiida_code.label }} code for AiiDA"
-#    shell: "cat {{ aiida_templates_folder }}/{{ aiida_code.label }}.code | {{ aiida_venv }}/bin/verdi code setup"
-#  when: aiida_check_code.rc != 0
-
-# hardcoded in options for the moment - move to a yml file after merging
-# https://github.com/aiidateam/aiida_core/pull/2723
 - name: "Setup {{ aiida_code.label }} code for AiiDA"  # noqa 306
   shell: |
     {{ aiida_venv }}/bin/verdi code setup --non-interactive\


### PR DESCRIPTION
So far:

- [x] updated aiida-core to 1.2.1
- [x] updated plugin packages, in accordance with https://github.com/aiidalab/aiidalab/blob/master/requirements.txt

- [x] The URL for the materials archive appears to have changed, so e.g. the SSSP pseudopotentials can't be downloaded (this is the same for ansible-role-quantumespresso)
- [ ] However, I guess we want to move to obtaining these *via* aiida-sssp/aiida-pseudo anyway. @sphuber what is the state of play on these? What should we add to the image for the tutorial week