### PR TITLE
fix systemd templates for profile name with dashes

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,6 +29,8 @@
         folder: "/usr/bin"
         executable: "pw.x"
         plugin: quantumespresso.pw
+      # dashes used to break systemd templates for daemon/rest api
+      aiida_profile_name: name-with-dashes
 
   post_tasks:
   - name: run pip check

--- a/tasks/aiida-core.yml
+++ b/tasks/aiida-core.yml
@@ -71,11 +71,11 @@
     src: profile.yml
     dest: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}/profile.yml"
 
-- name: "Check if AiiDA profile 'generic' has already been configured"
-  shell: "{{ aiida_venv }}/bin/verdi profile show generic"
+- name: "Check if AiiDA profile '{{ aiida_profile_name }}' has already been configured"
+  shell: "{{ aiida_venv }}/bin/verdi profile show {{ aiida_profile_name }}"
   failed_when: false
   changed_when: false
-  register: aiida_generic_profile
+  register: aiida_profile_show
 
 - name: "Set up AiiDA profile"
   # Need to use the full path because it's in a virtualenv
@@ -83,12 +83,12 @@
     {{ aiida_venv }}/bin/verdi setup \
     --non-interactive \
     --config {{ aiida_templates_folder }}/profile.yml
-  when: aiida_generic_profile.rc != 0
+  when: aiida_profile_show.rc != 0
 
 - name: "Set the default AiiDA profile"
   shell: "{{ aiida_venv }}/bin/verdi profile setdefault {{ aiida_profile_name }}"
   # not ideal - better to read default profile from config
-  when: aiida_generic_profile.rc != 0
+  when: aiida_profile_show.rc != 0
 
 - include_role:
     name: release_notes

--- a/templates/aiida-daemon@.service
+++ b/templates/aiida-daemon@.service
@@ -4,13 +4,13 @@ After=network.target postgresql.service rabbitmq-server.service
 
 [Service]
 Type=forking
-ExecStart={{ daemon_aiida_venv }}/bin/verdi -p %i daemon start
-PIDFile={{ daemon_user_home }}/.aiida/daemon/circus-%i.pid
+ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon start
+PIDFile={{ daemon_user_home }}/.aiida/daemon/circus-%I.pid
 # 2s delay to prevent read error on PID file
 ExecStartPost=/bin/sleep 2
 
-ExecStop={{ daemon_aiida_venv }}/bin/verdi -p %i daemon stop
-ExecReload={{ daemon_aiida_venv }}/bin/verdi -p %i daemon restart
+ExecStop={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon stop
+ExecReload={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon restart
 
 User={{ daemon_user }}
 Group={{ daemon_user }}
@@ -19,7 +19,7 @@ Restart=on-failure
 RestartSec=60
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=aiida-daemon-%i
+SyslogIdentifier=aiida-daemon-%I
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/aiida-rest@.service
+++ b/templates/aiida-rest@.service
@@ -6,7 +6,7 @@ After=network.target postgresql.service rabbitmq-server.service
 # simple: endless loop (does not exit)
 Type=simple
 # note: the default host 127.0.0.1 only allows access from within the VM
-ExecStart={{ daemon_aiida_venv }}/bin/verdi -p %i restapi -H 0.0.0.0
+ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%I" restapi -H 0.0.0.0
 
 User={{ daemon_user }}
 Group={{ daemon_user }}


### PR DESCRIPTION
When a profile name included dashes (e.g. my-profile), the dashes were
replaced by slashes in the systemd unit files for the AiiDA daemon / the
REST API, resulting in an error upon start (profile "my/profile" not
found).

This PR fixes the unit templates and also sets a profile name with a
dash for the molecule CI tests.