### PR TITLE
re-fix systemd templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,21 +79,22 @@ aiida_plugins: "{{ aiida_plugin_versions.keys() }}"
 aiida_pseudopotentials:
 - name: SSSP_1.1_efficiency
   file: SSSP_efficiency_pseudos.aiida
-  url: https://legacy-archive.materialscloud.org/file/2018.0001/v3
+  url: https://archive.materialscloud.org/record/file?record_id=22&file_id=ea53f742-5f57-40b9-854b-9c34dc2bdbb3&filename=SSSP_efficiency_pseudos.aiida
   home_page: https://materialscloud.org/sssp/
   description: >-
     Standard Solid State Pseudopotentials (efficiency)
     for the PBE functional
 - name: SSSP_1.1_precision
   file: SSSP_precision_pseudos.aiida
-  url: https://legacy-archive.materialscloud.org/file/2018.0001/v3
+  url: https://archive.materialscloud.org/record/file?record_id=22&file_id=a5278c7d-356e-40a7-8ca0-a7eaf0b63a9d&filename=SSSP_precision_pseudos.aiida
   home_page: https://materialscloud.org/sssp/
   description: >-
     Standard Solid State Pseudopotentials (precision)
     for the PBE functional
 - name: sg15-oncv-1.1
   file: sg15_oncv_upf_2015-10-07.tar.gz
-  url: http://www.quantum-simulation.org/potentials/sg15_oncv
+  url: http://www.quantum-simulation.org/potentials/sg15_oncv/sg15_oncv_upf_2015-10-07.tar.gz
+
   folder: sg15-oncv-1.1
   home_page: http://www.quantum-simulation.org/potentials/sg15_oncv/
   description: >-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 - name: reentry scan
-  shell: "{{ aiida_venv }}/bin/reentry scan"
+  command: "{{ aiida_venv }}/bin/reentry scan"

--- a/molecule/default/tests/test_plugins.yml
+++ b/molecule/default/tests/test_plugins.yml
@@ -1,5 +1,5 @@
 - name: print plugin version
-  shell: "{{ aiida_venv }}/bin/pip show {{ item.key }}"
+  command: "{{ aiida_venv }}/bin/pip show {{ item.key }}"
   changed_when: false
   register: aiida_pip_show
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -10,7 +10,7 @@
     include_vars: ../../defaults/main.yml
 
   - name: list PP families
-    shell: "{{ aiida_venv }}/bin/verdi data upf listfamilies"
+    command: "{{ aiida_venv }}/bin/verdi data upf listfamilies"
     changed_when: false
     register: aiida_pps
 
@@ -21,7 +21,7 @@
     with_items: "{{ aiida_pseudopotentials }}"
 
   - name: print aiida-core version
-    shell: "{{ aiida_venv }}/bin/pip show aiida-core"
+    command: "{{ aiida_venv }}/bin/pip show aiida-core"
     changed_when: false
     register: aiida_pip_show
 
@@ -33,3 +33,7 @@
   - name: check plugin versions
     include_tasks: tests/test_plugins.yml
     with_dict: "{{ aiida_plugin_versions }}"
+
+  - name: is daemon running?
+    command: "{{ aiida_venv }}/bin/verdi daemon status"
+    changed_when: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 ansible~=2.10.0
 # for testing
 molecule[docker]~=3.1.0
-docker~=4.2
+docker~=4.3.1

--- a/tasks/aiida-daemon.yml
+++ b/tasks/aiida-daemon.yml
@@ -31,13 +31,10 @@
   when: ansible_service_mgr == "systemd"
 
 - block:
-    # Replace with verdi daemon status once 1.1.0 is released. Check PR https://github.com/aiidateam/aiida-core/pull/3729
   - name: Check if the AiiDA daemon is running
-    shell: pgrep -a verdi | grep run_daemon | awk '{print $1}'
+    command: "{{ aiida_venv }}/bin/verdi -p {{ aiida_profile_name }} daemon status"
     changed_when: false
-    register: aiida_daemon_status
-    failed_when: aiida_daemon_status.rc not in [0,1]
+  rescue:
   - name: Start AiiDA Daemon
     command: "{{ aiida_venv }}/bin/verdi -p {{ aiida_profile_name }} daemon start"
-    when: aiida_daemon_status["stdout"] | length > 0
   when: ansible_service_mgr != "systemd"

--- a/tasks/aiida-pps.yml
+++ b/tasks/aiida-pps.yml
@@ -4,7 +4,7 @@
   become_user: "{{ root_user }}"
   tags: aiida_pps
   get_url:
-    url: "{{ pp.url }}/{{ pp.file }}"
+    url: "{{ pp.url }}"
     dest: "{{ aiida_data_folder }}/{{ pp.file }}"
     mode: "u+r"
   register: aiida_pp_download

--- a/tasks/aiida-prepare.yml
+++ b/tasks/aiida-prepare.yml
@@ -20,26 +20,22 @@
   - name: Check if Postgresql is running
     shell: pgrep postgres
     changed_when: false
-    register: postgres_status
-    failed_when: postgres_status.rc not in [0,1]
-
+  rescue:
   - name: Start Postgresql
     become: true
     become_user: "{{ aiida_postgres_user }}"
     command: "{{ aiida_postgres_bin_location }}/pg_ctl start -D {{ aiida_postgres_data_location }} -s -o '-p 5432' -w -t 300"
-    when: postgres_status.rc !=0
+  when: ansible_service_mgr != "systemd"
 
+- block:
   - name: Check if RabbitMQ is running
     shell: pgrep rabbitmq
     changed_when: false
-    register: rabbitmq_status
-    failed_when: rabbitmq_status.rc not in [0,1]
-
+  rescue:
   - name: Start RabbitMQ
     become: true
     become_user: "{{ root_user }}"
     shell: rabbitmq-server > /dev/null 2>&1 &
-    when: rabbitmq_status.rc !=0
   when: ansible_service_mgr != "systemd"
 
 - name: Setup postgres db

--- a/tasks/aiida-rest.yml
+++ b/tasks/aiida-rest.yml
@@ -31,10 +31,7 @@
   - name: Check if the AiiDA REST API is running
     shell: pgrep -a verdi | grep restapi | awk '{print $1}'
     changed_when: false
-    register: aiida_rest_status
-    failed_when: aiida_rest_status.rc not in [0,1]
-
+  rescue:
   - name: Start AiiDA REST API
     shell: "{{ aiida_venv }}/bin/verdi -p {{ aiida_profile_name }} restapi -H 0.0.0.0 &"
-    when: aiida_rest_status["stdout"] | length > 0
   when: ansible_service_mgr != "systemd"

--- a/templates/aiida-daemon@.service
+++ b/templates/aiida-daemon@.service
@@ -1,16 +1,16 @@
 [Unit]
-Description=AiiDA daemon service for profile %I
+Description=AiiDA daemon service for profile %i
 After=network.target postgresql.service rabbitmq-server.service
 
 [Service]
 Type=forking
-ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon start
-PIDFile={{ daemon_user_home }}/.aiida/daemon/circus-%I.pid
+ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%i" daemon start
+PIDFile={{ daemon_user_home }}/.aiida/daemon/circus-%i.pid
 # 2s delay to prevent read error on PID file
 ExecStartPost=/bin/sleep 2
 
-ExecStop={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon stop
-ExecReload={{ daemon_aiida_venv }}/bin/verdi -p "%I" daemon restart
+ExecStop={{ daemon_aiida_venv }}/bin/verdi -p "%i" daemon stop
+ExecReload={{ daemon_aiida_venv }}/bin/verdi -p "%i" daemon restart
 
 User={{ daemon_user }}
 Group={{ daemon_user }}
@@ -19,7 +19,7 @@ Restart=on-failure
 RestartSec=60
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=aiida-daemon-%I
+SyslogIdentifier=aiida-daemon-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/aiida-rest@.service
+++ b/templates/aiida-rest@.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=AiiDA REST API service for profile %I
+Description=AiiDA REST API service for profile %i
 After=network.target postgresql.service rabbitmq-server.service
 
 [Service]
 # simple: endless loop (does not exit)
 Type=simple
 # note: the default host 127.0.0.1 only allows access from within the VM
-ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%I" restapi -H 0.0.0.0
+ExecStart={{ daemon_aiida_venv }}/bin/verdi -p "%i" restapi -H 0.0.0.0
 
 User={{ daemon_user }}
 Group={{ daemon_user }}


### PR DESCRIPTION
Test that AiiDA daemon is running at the end of CI.
Uses more convenient "block/rescue" syntax.

Also re-fixes systemd templates which were effectively broken (during my manual tests, I somehow came to believe that %I was the right way - it turns out that %i seems to be... unfortunately the documentation of systemd doesn't really help)