### PR TITLE
👌 IMPROVE: Write pip constraints file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ aiida_examples_folder: "${HOME}"
 aiida_venv_base: "${HOME}/.virtualenvs"
 aiida_venv: "{{ aiida_venv_base }}/aiida"
 aiida_jupyter_venv: "{{ aiida_venv_base }}/jupyter"
+# this file can be used for subsequent installs into the environment,
+# pip install -c {{ aiida_venv_constraints }} new_pacakage
+aiida_venv_constraints: "{{ aiida_data_folder }}/constraints.txt"
 # these are packages required to run the install
 aiida_install_packages:
 - pip~=20.2

--- a/library/constraints.py
+++ b/library/constraints.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = """
+---
+module: constraints
+short_description: Create a pip constraints file
+author: 
+  - @chrisjsewell
+options:
+  src:
+    description: Path to requirements file
+    required: true
+  dest:
+    description: Path to write constraints file
+    required: true
+
+"""
+
+EXAMPLES = """
+- name: Create constraints
+  constraints:
+    src: /path/to/requirements.txt
+    dest: /path/to/constraints.txt
+
+"""
+
+# RETURN = """
+# output:
+#     description: ...
+#     returned: `changed == True`
+#     type: dict
+# """
+
+import os
+from pathlib import Path
+from ansible.module_utils.basic import AnsibleModule
+
+
+def _main():
+    """Entrypoint."""
+    module = AnsibleModule(
+        argument_spec={
+            "src": {"required": True, "type": "str"},
+            "dest": {"required": True, "type": "str"},
+        },
+        supports_check_mode=True,
+    )
+    src = Path(os.path.expandvars(os.path.expanduser(module.params["src"])))
+    dest = Path(os.path.expandvars(os.path.expanduser(module.params["dest"])))
+
+    if not src.exists():
+        module.fail_json(msg="src does not exist")
+        return
+
+    # get hash of current dest
+    hashed = module.sha256(str(dest)) if dest.exists() else None
+
+    # read requirements file
+    lines = [
+        line.strip()
+        for line in src.read_text("utf8").splitlines()
+        if (line.strip() and not line.strip().startswith("#"))
+    ]
+
+    # remove extras which are not allowed in constraints files, e.g. dep[extra]>0.1 -> dep>0.1
+    constraints = []
+    for line in lines:
+        if "[" not in line or "]" not in line:
+            constraints.append(line)
+            continue
+        start, end = line.split("[", 1)
+        constraints.append(start + end.split("]", 1)[1])
+
+    # write constraints file
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("\n".join(constraints))
+
+    # check if changed
+    changed = module.sha256(str(dest)) != hashed if hashed else True
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tasks/aiida-core.yml
+++ b/tasks/aiida-core.yml
@@ -18,6 +18,12 @@
     aiida_setup: "{{ aiida_setup_slurp.content | b64decode | from_json }}"
   register: aiida_pip_requirements
 
+- name: Write pip constraints file
+  # this is required for subsequent pip installs, e.g. by aiidalab
+  constraints:
+    src: "{{ aiida_data_folder }}/requirements.txt"
+    dest: "{{ aiida_data_folder }}/constraints.txt"
+
 - name: "create python{{ aiida_python_version }} virtual env: {{ aiida_venv }}"
   import_role:
     name: marvel-nccr.python

--- a/tasks/aiida-core.yml
+++ b/tasks/aiida-core.yml
@@ -22,7 +22,7 @@
   # this is required for subsequent pip installs, e.g. by aiidalab
   constraints:
     src: "{{ aiida_data_folder }}/requirements.txt"
-    dest: "{{ aiida_data_folder }}/constraints.txt"
+    dest: "{{ aiida_venv_constraints }}"
 
 - name: "create python{{ aiida_python_version }} virtual env: {{ aiida_venv }}"
   import_role:


### PR DESCRIPTION
This constraints file is no longer directly required in this role, since we now install aiida-core+plugins in a single command.
But it can be used by e.g. the aiidalab role, to ensure that installing additional packages into the aiida virtualenv does not break the existing environments: `pip install -c {{ aiida_venv_constraints }} new_pacakage`