### PR TITLE
🧪 TEST: Start molecule container with systemd as PID1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ aiida_install_packages:
 - reentry~=1.3
 - fastentrypoints~=0.12
 - ipykernel  # required to add the venv as a kernel
-- numpy~=1.17  # required for pymatgen install (to build c-extesions)
+- numpy~=1.17  # required for pymatgen install (see https://github.com/aiidateam/aiida-core/issues/4614)
 # these are additional to those extracted from aiida-core and its extras
 aiida_extra_packages: []
 aiida_jupyter_packages:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,6 +29,6 @@
         folder: "/usr/bin"
         executable: "pw.x"
         plugin: quantumespresso.pw
-      # dashes used to break systemd templates for daemon/rest api
-      aiida_profile_name: name-with-dashes
+      # TODO add dashes to name when https://github.com/marvel-nccr/ansible-role-aiida/issues/51 fixed
+      aiida_profile_name: general
       vm_headless: false  # test creation of desktop shortcut

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,6 +29,5 @@
         folder: "/usr/bin"
         executable: "pw.x"
         plugin: quantumespresso.pw
-      # TODO add dashes to name when https://github.com/marvel-nccr/ansible-role-aiida/issues/51 fixed
-      aiida_profile_name: general
+      aiida_profile_name: name-with-dashes  # use dashes to check systemd compatibility
       vm_headless: false  # test creation of desktop shortcut

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,12 +10,14 @@
     vars:
       nodejs_version: 12.x
       nodejs_install_npm_user: root
+
   - name: Create dummy pw executable
     copy:
       content: ""
       dest: /usr/bin/pw.x
       force: no
       mode: 0666
+
   - include_role:
       name: marvel-nccr.aiida
     vars:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,8 @@ driver:
 platforms:
 - name: instance
   image: "marvelnccr/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
-  command: "${MOLECULE_DOCKER_COMMAND:-sleep infinity}"
+  # by default the container will initialise with systemd as PID1
+  command: ${MOLECULE_DOCKER_COMMAND:-""}
   volumes:
   - /sys/fs/cgroup:/sys/fs/cgroup:ro
   privileged: true

--- a/tasks/aiida-core.yml
+++ b/tasks/aiida-core.yml
@@ -110,6 +110,7 @@
     value: >-
       AiiDA is installed in a Python {{ aiida_python_version }} venv: {{ aiida_venv }}.
       Type 'workon aiida' to get access to the 'verdi' commands.
+      See https://aiidateam.github.io/aiida-registry for plugin information.
 
 - name: Document plugins
   when: release_notes is defined and release_notes

--- a/tasks/aiida-daemon.yml
+++ b/tasks/aiida-daemon.yml
@@ -19,7 +19,7 @@
     daemon_aiida_venv: "{{ aiida_venv |  regex_replace('\\$\\{HOME}', current_user_home) }}"
   when: ansible_service_mgr == "systemd"
 
-- name: Start AiiDA Daemon system service
+- name: Start AiiDA Daemon system service (systemd)
   become: true
   become_user: "{{ root_user }}"
   systemd:
@@ -27,7 +27,7 @@
     enabled: true
     masked: false
     daemon-reload: true
-    state: restarted
+    state: started
   when: ansible_service_mgr == "systemd"
 
 - block:
@@ -35,6 +35,6 @@
     command: "{{ aiida_venv }}/bin/verdi -p {{ aiida_profile_name }} daemon status"
     changed_when: false
   rescue:
-  - name: Start AiiDA Daemon
+  - name: Start AiiDA Daemon (non-systemd)
     command: "{{ aiida_venv }}/bin/verdi -p {{ aiida_profile_name }} daemon start"
   when: ansible_service_mgr != "systemd"

--- a/tasks/aiida-deps-rhel.yml
+++ b/tasks/aiida-deps-rhel.yml
@@ -102,7 +102,6 @@
   command: "{{ aiida_postgres_bin_location }}/initdb {{ aiida_postgres_data_location }}"
   args:
     creates: "{{ aiida_postgres_data_location }}/pg_hba.conf"
-  when: ansible_service_mgr != "systemd"
 
 # Avoid password on postgres, fix in future so that we can use md5
 - name: put a trust configured pg_hba in place of the default

--- a/tasks/aiida-prepare.yml
+++ b/tasks/aiida-prepare.yml
@@ -1,7 +1,7 @@
 - name: Start services for systemd
   when: ansible_service_mgr == "systemd"
   block:
-  - name: Start Postgresql service
+  - name: Start Postgresql service (systemd)
     become: true
     become_user: "{{ root_user }}"
     service:
@@ -9,14 +9,14 @@
       state: "started"
       enabled: true
   # see https://github.com/marvel-nccr/quantum-mobile/issues/111
-  - name: Ensure correct RabbitMQ shutdown
+  - name: Ensure correct RabbitMQ shutdown (systemd)
     become: true
     become_user: "{{ root_user }}"
     lineinfile:
       path: /lib/systemd/system/rabbitmq-server.service
       regexp: ExecStop=/usr/sbin/rabbitmqctl stop
       line: ExecStop=/usr/sbin/rabbitmqctl shutdown
-  - name: Start RabbitMQ service
+  - name: Start RabbitMQ service (systemd)
     become: true
     become_user: "{{ root_user }}"
     service:
@@ -31,7 +31,7 @@
     shell: pgrep postgres
     changed_when: false
   rescue:
-  - name: Start Postgresql
+  - name: Start Postgresql (non-systemd)
     become: true
     become_user: "{{ aiida_postgres_user }}"
     command: "{{ aiida_postgres_bin_location }}/pg_ctl start -D {{ aiida_postgres_data_location }} -s -o '-p 5432' -w -t 300"
@@ -43,7 +43,7 @@
     shell: pgrep rabbitmq
     changed_when: false
   rescue:
-  - name: Start RabbitMQ
+  - name: Start RabbitMQ (non-systemd)
     become: true
     become_user: "{{ root_user }}"
     shell: rabbitmq-server > /dev/null 2>&1 &


### PR DESCRIPTION
I didn't realise before, but the geerlinguy docker images are set up to start by default with systemd.
This allows for the tests to run in an environment more closely representing that of the Quantum Mobile VM, and won't skip all the systemd tasks.

```console
root@instance:/# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 03:27 ?        00:00:01 /lib/systemd/systemd
root        21     1  0 03:27 ?        00:00:00 /lib/systemd/systemd-journald
62583       31     1  0 03:27 ?        00:00:00 /lib/systemd/systemd-timesyncd
systemd+    32     1  0 03:27 ?        00:00:00 /lib/systemd/systemd-resolved
syslog      35     1  0 03:27 ?        00:00:00 /usr/sbin/rsyslogd -n
root        42     1  0 03:27 tty2     00:00:00 /sbin/agetty -o -p -- \u --noclear tty2 linux
root        43     1  0 03:27 tty1     00:00:00 /sbin/agetty -o -p -- \u --noclear tty1 linux
root        44     1  0 03:27 tty3     00:00:00 /sbin/agetty -o -p -- \u --noclear tty3 linux
root        45     1  0 03:27 tty4     00:00:00 /sbin/agetty -o -p -- \u --noclear tty4 linux
root        46     1  0 03:27 tty5     00:00:00 /sbin/agetty -o -p -- \u --noclear tty5 linux
root        47     1  0 03:27 tty6     00:00:00 /sbin/agetty -o -p -- \u --noclear tty6 linux
postgres  4296     1  0 03:29 ?        00:00:00 /usr/lib/postgresql/10/bin/postgres -D /var/lib/postgresql/10/main -c config_file=/e
postgres  4298  4296  0 03:29 ?        00:00:00 postgres: 10/main: checkpointer process   
postgres  4299  4296  0 03:29 ?        00:00:00 postgres: 10/main: writer process   
postgres  4300  4296  0 03:29 ?        00:00:00 postgres: 10/main: wal writer process   
postgres  4301  4296  0 03:29 ?        00:00:00 postgres: 10/main: autovacuum launcher process   
postgres  4302  4296  0 03:29 ?        00:00:00 postgres: 10/main: stats collector process   
postgres  4303  4296  0 03:29 ?        00:00:00 postgres: 10/main: bgworker: logical replication launcher   
rabbitmq  4430     1  0 03:30 ?        00:00:00 /bin/sh /usr/sbin/rabbitmq-server
rabbitmq  4434  4430  1 03:30 ?        00:00:13 /usr/lib/erlang/erts-9.2/bin/beam.smp -W w -A 64 -P 1048576 -t 5000000 -stbt db -zdb
rabbitmq  4510     1  0 03:30 ?        00:00:00 /usr/lib/erlang/erts-9.2/bin/epmd -daemon
rabbitmq  4658  4434  0 03:30 ?        00:00:00 erl_child_setup 65536
rabbitmq  4684  4658  0 03:30 ?        00:00:00 inet_gethost 4
rabbitmq  4685  4684  0 03:30 ?        00:00:00 inet_gethost 4
root      7494     0  0 03:35 ?        00:00:00 /bin/sh
root      7586     0  0 03:35 ?        00:00:00 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node /tmp/vscode-r
root      7709  7586  0 03:35 ?        00:00:00 sh /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/server.sh --dis
root      7711  7709  1 03:35 ?        00:00:06 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node /root/.vscode
root      7744     0  0 03:35 ?        00:00:02 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node -e  ????const
root      7767     0  0 03:35 ?        00:00:01 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node -e  ????const
root      7783  7711  2 03:35 ?        00:00:08 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node /root/.vscode
root      7802  7711 56 03:35 ?        00:03:58 /root/.vscode-server/bin/d2e414d9e4239a252d1ab117bd7067f125afd80a/node /root/.vscode
root      7857  7783  0 03:35 pts/0    00:00:00 /bin/bash
root     12591     1  0 03:39 ?        00:00:00 /root/.virtualenvs/aiida/bin/python3.7 /root/.virtualenvs/aiida/bin/verdi -p name-wi
root     12608 12591  1 03:39 ?        00:00:02 /root/.virtualenvs/aiida/bin/python3.7 /root/.virtualenvs/aiida/bin/verdi -p name-wi
root     12611 12591  4 03:39 ?        00:00:06 /root/.virtualenvs/aiida/bin/python3.7 -c from circus import stats; stats.main() --e
postgres 12634  4296  0 03:39 ?        00:00:00 postgres: 10/main: aiida aiidadb 127.0.0.1(54878) idle
root     14193     0  0 03:41 ?        00:00:00 /bin/sh -c # Watch installed extensions ???trap "exit 0" 16 ???old=`ls -A --full-tim
root     14201     0  0 03:41 ?        00:00:00 /bin/sh -c # Watch machine settings ???trap "exit 0" 16 ???old=`ls -A --full-time se
root     14586 14201  0 03:42 ?        00:00:00 sleep 1
root     14590 14193  0 03:42 ?        00:00:00 sleep 1
root     14600  7857  0 03:42 pts/0    00:00:00 ps -ef
```

```console
root@instance:/# systemctl
UNIT                                  LOAD   ACTIVE     SUB       DESCRIPTION                                                      
dev-vda1.device                       loaded activating tentative /dev/vda1                                                        
-.mount                               loaded active     mounted   Root Mount                                                       
dev-hugepages.mount                   loaded active     mounted   Huge Pages File System                                           
dev-mqueue.mount                      loaded active     mounted   POSIX Message Queue File System                                  
etc-hostname.mount                    loaded active     mounted   /etc/hostname                                                    
etc-hosts.mount                       loaded active     mounted   /etc/hosts                                                       
etc-resolv.conf.mount                 loaded active     mounted   /etc/resolv.conf                                                 
sys-fs-fuse-connections.mount         loaded active     mounted   FUSE Control File System                                         
sys-kernel-debug.mount                loaded active     mounted   Kernel Debug File System                                         
tmp.mount                             loaded active     mounted   /tmp                                                             
cron-update.path                      loaded active     waiting   systemd-cron path monitor                                        
systemd-ask-password-console.path     loaded active     waiting   Dispatch Password Requests to Console Directory Watch            
systemd-ask-password-wall.path        loaded active     waiting   Forward Password Requests to Wall Directory Watch                
init.scope                            loaded active     running   System and Service Manager                                       
aiida-daemon@name-with-dashes.service loaded active     running   AiiDA daemon service for profile name-with-dashes                
getty-static.service                  loaded active     exited    getty on tty2-tty6 if dbus and logind are not available          
getty@tty1.service                    loaded active     running   Getty on tty1                                                    
getty@tty2.service                    loaded active     running   Getty on tty2                                                    
getty@tty3.service                    loaded active     running   Getty on tty3                                                    
getty@tty4.service                    loaded active     running   Getty on tty4                                                    
getty@tty5.service                    loaded active     running   Getty on tty5                                                    
getty@tty6.service                    loaded active     running   Getty on tty6                                                    
postgresql.service                    loaded active     exited    PostgreSQL RDBMS                                                 
postgresql@10-main.service            loaded active     running   PostgreSQL Cluster 10-main                                       
rabbitmq-server.service               loaded active     running   RabbitMQ Messaging Server                                        
rsyslog.service                       loaded active     running   System Logging Service                                           
systemd-journal-flush.service         loaded active     exited    Flush Journal to Persistent Storage                              
lines 1-28...skipping...
UNIT                                  LOAD   ACTIVE     SUB       DESCRIPTION                                                      
dev-vda1.device                       loaded activating tentative /dev/vda1                                                        
-.mount                               loaded active     mounted   Root Mount                                                       
dev-hugepages.mount                   loaded active     mounted   Huge Pages File System                                           
dev-mqueue.mount                      loaded active     mounted   POSIX Message Queue File System                                  
etc-hostname.mount                    loaded active     mounted   /etc/hostname                                                    
etc-hosts.mount                       loaded active     mounted   /etc/hosts                                                       
etc-resolv.conf.mount                 loaded active     mounted   /etc/resolv.conf                                                 
sys-fs-fuse-connections.mount         loaded active     mounted   FUSE Control File System                                         
sys-kernel-debug.mount                loaded active     mounted   Kernel Debug File System                                         
tmp.mount                             loaded active     mounted   /tmp                                                             
cron-update.path                      loaded active     waiting   systemd-cron path monitor                                        
systemd-ask-password-console.path     loaded active     waiting   Dispatch Password Requests to Console Directory Watch            
systemd-ask-password-wall.path        loaded active     waiting   Forward Password Requests to Wall Directory Watch                
init.scope                            loaded active     running   System and Service Manager                                       
aiida-daemon@name-with-dashes.service loaded active     running   AiiDA daemon service for profile name-with-dashes                
getty-static.service                  loaded active     exited    getty on tty2-tty6 if dbus and logind are not available          
getty@tty1.service                    loaded active     running   Getty on tty1                                                    
getty@tty2.service                    loaded active     running   Getty on tty2                                                    
getty@tty3.service                    loaded active     running   Getty on tty3                                                    
getty@tty4.service                    loaded active     running   Getty on tty4                                                    
getty@tty5.service                    loaded active     running   Getty on tty5                                                    
getty@tty6.service                    loaded active     running   Getty on tty6                                                    
postgresql.service                    loaded active     exited    PostgreSQL RDBMS                                                 
postgresql@10-main.service            loaded active     running   PostgreSQL Cluster 10-main                                       
rabbitmq-server.service               loaded active     running   RabbitMQ Messaging Server                                        
rsyslog.service                       loaded active     running   System Logging Service                                           
systemd-journal-flush.service         loaded active     exited    Flush Journal to Persistent Storage                              
systemd-journald.service              loaded active     running   Journal Service                                                  
systemd-modules-load.service          loaded active     exited    Load Kernel Modules                                              
systemd-random-seed.service           loaded active     exited    Load/Save Random Seed                                            
systemd-remount-fs.service            loaded active     exited    Remount Root and Kernel File Systems                             
systemd-resolved.service              loaded active     running   Network Name Resolution                                          
systemd-sysctl.service                loaded active     exited    Apply Kernel Variables                                           
systemd-timesyncd.service             loaded active     running   Network Time Synchronization                                     
systemd-tmpfiles-setup-dev.service    loaded active     exited    Create Static Device Nodes in /dev                               
systemd-tmpfiles-setup.service        loaded active     exited    Create Volatile Files and Directories                            
systemd-update-utmp.service           loaded active     exited    Update UTMP about System Boot/Shutdown                           
systemd-user-sessions.service         loaded active     exited    Permit User Sessions                                             
-.slice                               loaded active     active    Root Slice                                                       
system-aiida\x2ddaemon.slice          loaded active     active    system-aiida\x2ddaemon.slice                                     
system-getty.slice                    loaded active     active    system-getty.slice                                               
system-postgresql.slice               loaded active     active    system-postgresql.slice                                          
system.slice                          loaded active     active    System Slice                                                     
syslog.socket                         loaded active     running   Syslog Socket                                                    
systemd-initctl.socket                loaded active     listening /dev/initctl Compatibility Named Pipe                            
systemd-journald-audit.socket         loaded active     running   Journal Audit Socket                                             
systemd-journald-dev-log.socket       loaded active     running   Journal Socket (/dev/log)                                        
systemd-journald.socket               loaded active     running   Journal Socket                                                   
swap.swap                             loaded active     active    /swap                                                            
basic.target                          loaded active     active    Basic System                                                     
cron.target                           loaded active     active    systemd-cron                                                     
cryptsetup.target                     loaded active     active    Local Encrypted Volumes                                          
getty.target                          loaded active     active    Login Prompts                                                    
graphical.target                      loaded active     active    Graphical Interface                                              
local-fs-pre.target                   loaded active     active    Local File Systems (Pre)                                         
local-fs.target                       loaded active     active    Local File Systems                                               
multi-user.target                     loaded active     active    Multi-User System                                                
network.target                        loaded active     active    Network                                                          
nss-lookup.target                     loaded active     active    Host and Network Name Lookups                                    
paths.target                          loaded active     active    Paths                                                            
remote-fs.target                      loaded active     active    Remote File Systems                                              
slices.target                         loaded active     active    Slices                                                           
sockets.target                        loaded active     active    Sockets                                                          
swap.target                           loaded active     active    Swap                                                             
sysinit.target                        loaded active     active    System Initialization                                            
time-sync.target                      loaded active     active    System Time Synchronized                                         
timers.target                         loaded active     active    Timers                                                           
apt-daily-upgrade.timer               loaded active     waiting   Daily apt upgrade and clean activities                           
apt-daily.timer                       loaded active     waiting   Daily apt download activities                                    
cron-daily.timer                      loaded active     waiting   systemd-cron daily timer                                         
cron-hourly.timer                     loaded active     waiting   systemd-cron hourly timer                                        
cron-monthly.timer                    loaded active     waiting   systemd-cron monthly timer                                       
cron-sysstat-root-0.timer             loaded active     waiting   [Timer] "5-55/10 * * * * root command -v debian-sa1 > /dev/null &&
cron-sysstat-root-1.timer             loaded active     waiting   [Timer] "59 23 * * * root command -v debian-sa1 > /dev/null && deb
cron-weekly.timer                     loaded active     waiting   systemd-cron weekly timer                                        
fstrim.timer                          loaded active     waiting   Discard unused blocks once a week                                
motd-news.timer                       loaded active     waiting   Message of the Day                                               
systemd-tmpfiles-clean.timer          loaded active     waiting   Daily Cleanup of Temporary Directories                           

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.

78 loaded units listed. Pass --all to see loaded but inactive units, too.
To show all installed unit files use 'systemctl list-unit-files'.
```