### PR TITLE
👌 IMPROVE: Use `/tmp` folder for psuedo downloads

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ aiida_extras:
 - rest
 - docs
 - atomic_tools
+aiida_temp_folder: "/tmp"
 aiida_data_folder: "${HOME}/.local/share/aiida"
 aiida_templates_folder: "${HOME}/.local/share/aiida"
 aiida_source_folder: "${HOME}/src"

--- a/tasks/aiida-pps-oncv.yml
+++ b/tasks/aiida-pps-oncv.yml
@@ -3,7 +3,7 @@
   become: true
   become_user: "{{ root_user }}"
   file:
-    path: "{{ aiida_data_folder | regex_replace('\\$\\{HOME}', current_user_home) }}/{{ pp.folder }}"
+    path: "{{ aiida_temp_folder | regex_replace('\\$\\{HOME}', current_user_home) }}/{{ pp.folder }}"
     state: directory
 
 - name: "Unpack {{ pp.file }}"
@@ -11,7 +11,7 @@
   become_user: "{{ root_user }}"
   unarchive:
     src: "{{ aiida_pp_download.dest }}"
-    dest: "{{ aiida_data_folder }}/{{ pp.folder }}"
+    dest: "{{ aiida_temp_folder }}/{{ pp.folder }}"
     remote_src: true
   register: oncv_extract
 
@@ -20,7 +20,7 @@
   become_user: "{{ root_user }}"
   copy:
     src: oncv-select-pps.sh
-    dest: "{{ aiida_data_folder }}/{{ pp.folder }}"
+    dest: "{{ aiida_temp_folder }}/{{ pp.folder }}"
   when: oncv_extract.changed
 
 - name: run script to select pseudos
@@ -28,9 +28,9 @@
   become_user: "{{ root_user }}"
   shell: bash oncv-select-pps.sh
   args:
-    chdir: "{{ aiida_data_folder }}/{{ pp.folder }}"
+    chdir: "{{ aiida_temp_folder }}/{{ pp.folder }}"
   when: oncv_extract.changed
 
 - name: Add upf family
-  shell: "{{ aiida_venv }}/bin/verdi data upf uploadfamily {{ aiida_data_folder }}/{{ pp.folder }} {{ pp.name }} '{{ pp.description }}'"
+  shell: "{{ aiida_venv }}/bin/verdi data upf uploadfamily {{ aiida_temp_folder }}/{{ pp.folder }} {{ pp.name }} '{{ pp.description }}'"
   when: oncv_extract.changed

--- a/tasks/aiida-pps-sssp.yml
+++ b/tasks/aiida-pps-sssp.yml
@@ -1,2 +1,2 @@
 - name: Import {{ pp.file }}  # noqa 301
-  shell: "{{ aiida_venv }}/bin/verdi import -n {{ aiida_data_folder }}/{{ pp.file }}"
+  shell: "{{ aiida_venv }}/bin/verdi import -n {{ aiida_temp_folder }}/{{ pp.file }}"

--- a/tasks/aiida-pps.yml
+++ b/tasks/aiida-pps.yml
@@ -5,7 +5,7 @@
   tags: aiida_pps
   get_url:
     url: "{{ pp.url }}"
-    dest: "{{ aiida_data_folder }}/{{ pp.file }}"
+    dest: "{{ aiida_temp_folder }}/{{ pp.file }}"
     mode: "u+r"
   register: aiida_pp_download
   until: not aiida_pp_download.failed


### PR DESCRIPTION
It is unneccessary for these to persist,
once they have been uploaded into the AiiDA database