### PR TITLE
‼️ BREAKING: Label codes by executable version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,7 @@ aiida_computer_run_folder: "${HOME}/.aiida_run"
 
   # - name: name
   #   plugin: plugin.name
+  #   version: 1.0 # version of the executable, not plugin
   #   folder: /path/to
   #   executable: executable.exe  # if this is omitted, then the `name` will be used
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,5 +29,6 @@
         folder: "/usr/bin"
         executable: "pw.x"
         plugin: quantumespresso.pw
+        version: "6.5"
       aiida_profile_name: name-with-dashes  # use dashes to check systemd compatibility
       vm_headless: false  # test creation of desktop shortcut

--- a/tasks/aiida-code.yml
+++ b/tasks/aiida-code.yml
@@ -2,12 +2,12 @@
   include_tasks: code-setup.yml
   vars:
   - aiida_code:
-      label: "{{ plugin.value.code_prefix }}-{{ plugin.value.version }}-{{ code_params.name }}"
+      label: "{{ plugin.value.code_prefix }}-{{ code_params.name if code_params.name != plugin.value.code_prefix else '' }}-{{ code_params.version }}"
       template: code.yml
       executable: "{{ code_params.executable | default(code_params.name) }}"
       folder: "{{ code_params.folder }}"
       plugin: "{{ code_params.plugin }}"
-      description: "{{ plugin.key }} {{ code_params.name }} v{{ plugin.value.version }}"
+      description: "{{ plugin.key }} {{ code_params.name }}, original plugin version {{ plugin.value.version }}, executable version {{ code_params.version }}"
   loop: "{{ lookup('vars', plugin.value.codes_var) }}"
   loop_control:
     loop_var: code_params

--- a/tasks/aiida-code.yml
+++ b/tasks/aiida-code.yml
@@ -2,7 +2,7 @@
   include_tasks: code-setup.yml
   vars:
   - aiida_code:
-      label: "{{ plugin.value.code_prefix }}-{{ code_params.name if code_params.name != plugin.value.code_prefix else '' }}-{{ code_params.version }}"
+      label: "{{ plugin.value.code_prefix }}{{ '-' + code_params.name if code_params.name != plugin.value.code_prefix else '' }}-{{ code_params.version }}"
       template: code.yml
       executable: "{{ code_params.executable | default(code_params.name) }}"
       folder: "{{ code_params.folder }}"


### PR DESCRIPTION
Rather than by plugin version.
Note this required the addition of the `version` key to all code roles.
Also remove duplication if `prefix == code name`, e.g. rather than `cp2k-cp2k-1` it will be `cp2k--1`