### PR TITLE
🐛 FIX: pymatgen/numpy compilation issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,7 +92,7 @@ aiida_plugins:
     code_prefix: cp2k
     codes_var: "cp2k_executables"
   aiida-fleur:
-    version: "1.1.2"
+    version: "1.1.4"
     code_prefix: fleur
     codes_var: "fleur_executables"
   aiida-nwchem:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -38,6 +38,14 @@
     command: "{{ aiida_venv }}/bin/pip check --no-color"
     changed_when: false
 
+  # pymatgen can fail when the numpy it was compiled against is downgraded/upgraded
+  # (e.g. due to a package pinning numpy)
+  # ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
+  # this is not identified by pip check!
+  - name: test pymatgen import
+    command: "{{ aiida_venv }}/bin/python -c 'import pymatgen'"
+    changed_when: false
+
   - name: is daemon running?
     command: "{{ aiida_venv }}/bin/verdi daemon status"
     changed_when: false


### PR DESCRIPTION
⬆️ UPGRADE: aiida-fleur 1.1.4

Earlier versions were pinning numpy to a lower version,
causing conflicts with the pymatgen compilation
which was built against a newer numpy version that was then forced to downgrade.

Note, this issue is not identified by `pip check`!

Also added a test for the pymatgen import, such that the first commit (without the upgrade) should fail, then the 2nd should pass