### PR TITLE
feat: modularize profile setup

### DIFF
--- a/tasks/aiida-core.yml
+++ b/tasks/aiida-core.yml
@@ -62,32 +62,6 @@
     path: "{{ aiida_venv }}/bin/activate"
     line: 'eval "$(_VERDI_COMPLETE=bash_source verdi)"'
 
-- name: copy profile config
-  become: true
-  become_user: "{{ root_user }}"
-  template:
-    src: profile.yml
-    dest: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}/profile.yml"
-
-- name: "Check if AiiDA profile '{{ aiida_profile_name }}' has already been configured"
-  shell: "{{ aiida_venv }}/bin/verdi profile show {{ aiida_profile_name }}"
-  failed_when: false
-  changed_when: false
-  register: aiida_profile_show
-
-- name: "Set up AiiDA profile"
-  # Need to use the full path because it's in a virtualenv
-  shell: |
-    {{ aiida_venv }}/bin/verdi setup \
-    --non-interactive \
-    --config {{ aiida_templates_folder }}/profile.yml
-  when: aiida_profile_show.rc != 0
-
-- name: "Set the default AiiDA profile"
-  shell: "{{ aiida_venv }}/bin/verdi profile setdefault {{ aiida_profile_name }}"
-  # not ideal - better to read default profile from config
-  when: aiida_profile_show.rc != 0
-
 - name: Document aiida-core (version)
   when: release_notes is defined and release_notes
   include_role:

--- a/tasks/aiida-folders.yml
+++ b/tasks/aiida-folders.yml
@@ -1,0 +1,17 @@
+- name: add aiida templates folder
+  become: true
+  become_user: "{{ root_user }}"
+  file:
+    path: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
+    state: "directory"
+    mode: 0755
+    owner: "{{ current_user }}"
+
+- name: add aiida data folder
+  become: true
+  become_user: "{{ root_user }}"
+  file:
+    path: "{{ aiida_data_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
+    state: "directory"
+    mode: 0755
+    owner: "{{ current_user }}"

--- a/tasks/aiida-prepare.yml
+++ b/tasks/aiida-prepare.yml
@@ -47,36 +47,3 @@
     become: true
     become_user: "{{ root_user }}"
     shell: rabbitmq-server > /dev/null 2>&1 &
-
-- name: Setup postgres db
-  become: true
-  become_user: "{{ aiida_postgres_user }}"
-  postgresql_db:
-    name: "{{ aiida_postgres_db }}"
-
-- name: Setup postgres db user
-  become: true
-  become_user: "{{ aiida_postgres_user }}"
-  postgresql_user:
-    db: "{{ aiida_postgres_db }}"
-    name: "{{ aiida_postgres_db_user }}"
-    password: "{{ aiida_postgres_db_pw }}"
-    encrypted: true
-
-- name: add aiida templates folder
-  become: true
-  become_user: "{{ root_user }}"
-  file:
-    path: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
-    state: "directory"
-    mode: 0755
-    owner: "{{ current_user }}"
-
-- name: add aiida data folder
-  become: true
-  become_user: "{{ root_user }}"
-  file:
-    path: "{{ aiida_data_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}"
-    state: "directory"
-    mode: 0755
-    owner: "{{ current_user }}"

--- a/tasks/aiida-profile.yml
+++ b/tasks/aiida-profile.yml
@@ -1,0 +1,40 @@
+- name: Setup postgres db
+  become: true
+  become_user: "{{ aiida_postgres_user }}"
+  postgresql_db:
+    name: "{{ aiida_postgres_db }}"
+
+- name: Setup postgres db user
+  become: true
+  become_user: "{{ aiida_postgres_user }}"
+  postgresql_user:
+    db: "{{ aiida_postgres_db }}"
+    name: "{{ aiida_postgres_db_user }}"
+    password: "{{ aiida_postgres_db_pw }}"
+    encrypted: true
+
+- name: copy profile config
+  become: true
+  become_user: "{{ root_user }}"
+  template:
+    src: profile.yml
+    dest: "{{ aiida_templates_folder |  regex_replace('\\$\\{HOME}', current_user_home) }}/profile.yml"
+
+- name: "Check if AiiDA profile '{{ aiida_profile_name }}' has already been configured"
+  shell: "{{ aiida_venv }}/bin/verdi profile show {{ aiida_profile_name }}"
+  failed_when: false
+  changed_when: false
+  register: aiida_profile_show
+
+- name: "Set up AiiDA profile"
+  # Need to use the full path because it's in a virtualenv
+  shell: |
+    {{ aiida_venv }}/bin/verdi setup \
+    --non-interactive \
+    --config {{ aiida_templates_folder }}/profile.yml
+  when: aiida_profile_show.rc != 0
+
+- name: "Set the default AiiDA profile"
+  shell: "{{ aiida_venv }}/bin/verdi profile setdefault {{ aiida_profile_name }}"
+  # not ideal - better to read default profile from config
+  when: aiida_profile_show.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,6 @@
 - include_tasks: aiida-deps-debian.yml
   tags: [aiida_deps]
   when: ansible_os_family|lower == 'debian'
-- import_tasks: virtualenvwrapper.yml
-  tags: [aiida_venv]
 
 # Start and setup Postgresql and RabbitMQ, create folders
 - import_tasks: aiida-prepare.yml
@@ -25,6 +23,10 @@
 # install and setup AiiDA, including profile etc.
 - import_tasks: aiida-core.yml
   tags: [aiida, aiida_core]
+# if this is moved before aiida-core, install of package fails
+# because pkg_resources is not found
+- import_tasks: virtualenvwrapper.yml
+  tags: [aiida_venv]
 - import_tasks: jupyter.yml
   tags: [aiida, aiida_core, aiida_jupyter]
 - import_tasks: aiida-profile.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,18 +13,22 @@
 - include_tasks: aiida-deps-debian.yml
   tags: [aiida_deps]
   when: ansible_os_family|lower == 'debian'
+- import_tasks: virtualenvwrapper.yml
+  tags: [aiida_venv]
 
 # Start and setup Postgresql and RabbitMQ, create folders
 - import_tasks: aiida-prepare.yml
   tags: [aiida, aiida_prepare]
+- import_tasks: aiida-folders.yml
+  tags: [aiida, aiida_folders]
 
 # install and setup AiiDA, including profile etc.
 - import_tasks: aiida-core.yml
   tags: [aiida, aiida_core]
-- import_tasks: virtualenvwrapper.yml
-  tags: [aiida, aiida_core, aiida_venv]
 - import_tasks: jupyter.yml
   tags: [aiida, aiida_core, aiida_jupyter]
+- import_tasks: aiida-profile.yml
+  tags: [aiida, aiida_core, aiida_profile]
 - import_tasks: aiida-daemon.yml
   tags: [aiida_daemon, aiida_core]
 - import_tasks: aiida-rest.yml

--- a/tasks/virtualenvwrapper.yml
+++ b/tasks/virtualenvwrapper.yml
@@ -1,10 +1,17 @@
-- name: Add virtualenvwrapper package (pip{{ aiida_python_version }})
+- name: Add setuptools
   become: true
   become_user: "{{ root_user }}"
   pip:
     executable: "/usr/local/bin/pip{{ aiida_python_version }}"
     name:
     - setuptools
+
+- name: Add virtualenvwrapper package (pip{{ aiida_python_version }})
+  become: true
+  become_user: "{{ root_user }}"
+  pip:
+    executable: "/usr/local/bin/pip{{ aiida_python_version }}"
+    name:
     - virtualenv
     - virtualenvwrapper
 

--- a/tasks/virtualenvwrapper.yml
+++ b/tasks/virtualenvwrapper.yml
@@ -4,6 +4,7 @@
   pip:
     executable: "/usr/local/bin/pip{{ aiida_python_version }}"
     name:
+    - setuptools
     - virtualenv
     - virtualenvwrapper
 


### PR DESCRIPTION
Move profile-specific setup into separate file, so that the role can be used to just prepare the stage for an AiiDA installation e.g. via

  ansible-playbook playbook.yml --tags aiida_deps,aiida_prepare